### PR TITLE
Fix: Initial state doesn't work in Rails 4.2

### DIFF
--- a/lib/state_machine/integrations/active_record.rb
+++ b/lib/state_machine/integrations/active_record.rb
@@ -472,7 +472,7 @@ module StateMachine
           define_helper :instance, <<-end_eval, __FILE__, __LINE__ + 1
             def initialize(*)
               super do |*args|
-                self.class.state_machines.initialize_states(self, :static => false)
+                self.class.state_machines.initialize_states(self)
                 yield(*args) if block_given?
               end
             end


### PR DESCRIPTION
Props @aripollak
